### PR TITLE
fix bed file formatting

### DIFF
--- a/SoloTE_pipeline.py
+++ b/SoloTE_pipeline.py
@@ -229,7 +229,7 @@ te_annotation = tecounts2[4].str.split(":",expand=True)
 te_final_df = pd.concat([te_table,te_annotation],axis=1)
 te_final_df.columns=['TE_original_id','barcode','counts','Subfamily','Family','Class']
 te_final_df.replace("\?","",inplace=True,regex=True)
-locus_tes = te_final_df[te_final_df['TE_original_id'].str.contains("SoloTE\|chr")]
+locus_tes = te_final_df[te_final_df['TE_original_id'].str.contains("SoloTE\|*.\|")]
 
 legacy_df = te_final_df.groupby(['TE_original_id','barcode'],as_index=False)['counts'].sum()
 locus_df = locus_tes.groupby(['TE_original_id','barcode'],as_index=False)['counts'].sum()


### PR DESCRIPTION
According to https://github.com/bvaldebenitom/SoloTE/issues/30#issuecomment-1721876808 the pattern for reads mapping uniquely to TEs is: `SoloTE|<chr>|<Start>|<End>|<TEfamily>`

and for reads mapping to multiple locations it is: `SoloTE|<TEfamily>`

So anything between at least two '|'.


This should add compatibility of SoloTE with bed + gtf file combinations where there is consistently *no* "chr" in the chromosome naming scheme of both files.